### PR TITLE
feat: upload DICOM file and return a record

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "express": "4.18.3",
+        "multer": "1.4.5-lts.1",
         "uuid": "9.0.1"
       },
       "devDependencies": {
@@ -2250,6 +2251,11 @@
         "node": ">= 8"
       }
     },
+    "node_modules/append-field": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/append-field/-/append-field-1.0.0.tgz",
+      "integrity": "sha512-klpgFSWLW1ZEs8svjfb7g4qWY0YS5imI82dTg+QahUvJ8YqAY0P10Uk8tTyh9ZGuYEZEMaeJYCF5BFuX552hsw=="
+    },
     "node_modules/argparse": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
@@ -2807,8 +2813,18 @@
     "node_modules/buffer-from": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
-      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
-      "dev": true
+      "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="
+    },
+    "node_modules/busboy": {
+      "version": "1.6.0",
+      "resolved": "https://registry.npmjs.org/busboy/-/busboy-1.6.0.tgz",
+      "integrity": "sha512-8SFQbg/0hQ9xy3UNTB0YEnsNBbWfhf7RtnzpL7TkBiTBRfrQ9Fxcnz7VJsleJpyp6rVLvXiuORqjlHi5q+PYuA==",
+      "dependencies": {
+        "streamsearch": "^1.1.0"
+      },
+      "engines": {
+        "node": ">=10.16.0"
+      }
     },
     "node_modules/bytes": {
       "version": "3.1.2",
@@ -3068,6 +3084,20 @@
       "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==",
       "dev": true
     },
+    "node_modules/concat-stream": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.2.tgz",
+      "integrity": "sha512-27HBghJxjiZtIk3Ycvn/4kbJk/1uZuJFfuPEns6LaEvpvG1f0hTea8lilrouyo9mVc2GWdcEZ8OLoGmSADlrCw==",
+      "engines": [
+        "node >= 0.8"
+      ],
+      "dependencies": {
+        "buffer-from": "^1.0.0",
+        "inherits": "^2.0.3",
+        "readable-stream": "^2.2.2",
+        "typedarray": "^0.0.6"
+      }
+    },
     "node_modules/constant-case": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/constant-case/-/constant-case-3.0.4.tgz",
@@ -3122,6 +3152,11 @@
       "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.4.tgz",
       "integrity": "sha512-LDx6oHrK+PhzLKJU9j5S7/Y3jM/mUHvD/DeI1WQmJn652iPC5Y4TBzC9l+5OMOXlyTTA+SmVUPm0HQUwpD5Jqw==",
       "dev": true
+    },
+    "node_modules/core-util-is": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
+      "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ=="
     },
     "node_modules/create-jest": {
       "version": "29.7.0",
@@ -7996,9 +8031,19 @@
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
       "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
-      "dev": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/mkdirp": {
+      "version": "0.5.6",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.6.tgz",
+      "integrity": "sha512-FP+p8RB8OWpF3YZBCrP5gtADmtXApB5AMLn+vdyA+PyxCjrCs00mjyUozssO33cwDeT3wNGdLxJ5M//YqtHAJw==",
+      "dependencies": {
+        "minimist": "^1.2.6"
+      },
+      "bin": {
+        "mkdirp": "bin/cmd.js"
       }
     },
     "node_modules/ms": {
@@ -8006,6 +8051,23 @@
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
       "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
       "dev": true
+    },
+    "node_modules/multer": {
+      "version": "1.4.5-lts.1",
+      "resolved": "https://registry.npmjs.org/multer/-/multer-1.4.5-lts.1.tgz",
+      "integrity": "sha512-ywPWvcDMeH+z9gQq5qYHCCy+ethsk4goepZ45GLD63fOu0YcNecQxi64nDs3qluZB+murG3/D4dJ7+dGctcCQQ==",
+      "dependencies": {
+        "append-field": "^1.0.0",
+        "busboy": "^1.0.0",
+        "concat-stream": "^1.5.2",
+        "mkdirp": "^0.5.4",
+        "object-assign": "^4.1.1",
+        "type-is": "^1.6.4",
+        "xtend": "^4.0.0"
+      },
+      "engines": {
+        "node": ">= 6.0.0"
+      }
     },
     "node_modules/natural-compare": {
       "version": "1.4.0",
@@ -8166,7 +8228,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
-      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -8606,6 +8667,11 @@
       "integrity": "sha512-xWGDIW6x921xtzPkhiULtthJHoJvBbF3q26fzloPCK0hsvxtPVelvftw3zjbHWSkR2km9Z+4uxbDDK/6Zw9B8w==",
       "dev": true
     },
+    "node_modules/process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
+    },
     "node_modules/prompts": {
       "version": "2.4.2",
       "resolved": "https://registry.npmjs.org/prompts/-/prompts-2.4.2.tgz",
@@ -8734,6 +8800,30 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
       "dev": true
+    },
+    "node_modules/readable-stream": {
+      "version": "2.3.8",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
+      "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
+      "dependencies": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      }
+    },
+    "node_modules/readable-stream/node_modules/isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ=="
+    },
+    "node_modules/readable-stream/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
     },
     "node_modules/readdirp": {
       "version": "3.6.0",
@@ -9297,6 +9387,27 @@
         "node": ">= 0.8"
       }
     },
+    "node_modules/streamsearch": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/streamsearch/-/streamsearch-1.1.0.tgz",
+      "integrity": "sha512-Mcc5wHehp9aXz1ax6bZUyY5afg9u2rv5cqQI3mRrYkGC8rW2hM02jWuwjtL++LS5qinSyhj2QfLyNsuc+VsExg==",
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "dependencies": {
+        "safe-buffer": "~5.1.0"
+      }
+    },
+    "node_modules/string_decoder/node_modules/safe-buffer": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+      "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+    },
     "node_modules/string-length": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/string-length/-/string-length-4.0.2.tgz",
@@ -9846,6 +9957,11 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/typedarray": {
+      "version": "0.0.6",
+      "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
+      "integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA=="
+    },
     "node_modules/typescript": {
       "version": "5.4.2",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.4.2.tgz",
@@ -9951,6 +10067,11 @@
       "dependencies": {
         "punycode": "^2.1.0"
       }
+    },
+    "node_modules/util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="
     },
     "node_modules/utils-merge": {
       "version": "1.0.1",
@@ -10164,6 +10285,14 @@
       },
       "engines": {
         "node": "^12.13.0 || ^14.15.0 || >=16.0.0"
+      }
+    },
+    "node_modules/xtend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+      "engines": {
+        "node": ">=0.4"
       }
     },
     "node_modules/y18n": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "@faker-js/faker": "^8.4.1",
         "@shopify/eslint-plugin": "^44.0.0",
         "@shopify/prettier-config": "^1.1.2",
+        "@types/jest": "29.5.12",
         "eslint": "^8.57.0",
         "fishery": "^2.2.2",
         "jest": "^29.7.0",
@@ -1778,6 +1779,16 @@
       "dev": true,
       "dependencies": {
         "@types/istanbul-lib-report": "*"
+      }
+    },
+    "node_modules/@types/jest": {
+      "version": "29.5.12",
+      "resolved": "https://registry.npmjs.org/@types/jest/-/jest-29.5.12.tgz",
+      "integrity": "sha512-eDC8bTvT/QhYdxJAulQikueigY5AsdBRH2yDKW3yveW7svY3+DzN84/2NUgkw10RTiJbWqZrTtoGVdYlvFJdLw==",
+      "dev": true,
+      "dependencies": {
+        "expect": "^29.0.0",
+        "pretty-format": "^29.0.0"
       }
     },
     "node_modules/@types/json-schema": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,8 @@
       "name": "dicom-service",
       "version": "0.1.0",
       "dependencies": {
-        "express": "4.18.3"
+        "express": "4.18.3",
+        "uuid": "9.0.1"
       },
       "devDependencies": {
         "@faker-js/faker": "^8.4.1",
@@ -9957,6 +9958,18 @@
       "integrity": "sha512-pMZTvIkT1d+TFGvDOqodOclx0QWkkgi6Tdoa8gC8ffGAAqz9pzPTZWAybbsHHoED/ztMtkv/VoYTYyShUn81hA==",
       "engines": {
         "node": ">= 0.4.0"
+      }
+    },
+    "node_modules/uuid": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
+      "bin": {
+        "uuid": "dist/bin/uuid"
       }
     },
     "node_modules/v8-to-istanbul": {

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   },
   "dependencies": {
     "express": "4.18.3",
+    "multer": "1.4.5-lts.1",
     "uuid": "9.0.1"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -16,7 +16,8 @@
     "test:watch": "jest --watch"
   },
   "dependencies": {
-    "express": "4.18.3"
+    "express": "4.18.3",
+    "uuid": "9.0.1"
   },
   "devDependencies": {
     "@faker-js/faker": "^8.4.1",

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
     "@faker-js/faker": "^8.4.1",
     "@shopify/eslint-plugin": "^44.0.0",
     "@shopify/prettier-config": "^1.1.2",
+    "@types/jest": "29.5.12",
     "eslint": "^8.57.0",
     "fishery": "^2.2.2",
     "jest": "^29.7.0",

--- a/src/app.js
+++ b/src/app.js
@@ -8,16 +8,30 @@ const {
   DICOMRecordsController,
 } = require('./controllers/dicom-records-controller');
 const {FileUploadService} = require('./services/file-upload-service');
+const {
+  DICOMRecordCreateValidator,
+} = require('./validators/dicom-record-create-validator');
 const {useRoutes} = require('./routes');
 
-const fileUploadService = new FileUploadService({
-  destination: FILE_UPLOAD_DESTINATION,
-  maxFileSize: FILE_UPLOAD_MAX_SIZE,
-});
 const dicomRecordsController = new DICOMRecordsController();
+const dicomRecordCreateValidator = new DICOMRecordCreateValidator({
+  fileFieldName: dicomRecordsController.fileUploadFieldName,
+});
+const dicomFileUploadService = new FileUploadService({
+  destination: FILE_UPLOAD_DESTINATION,
+  fileFieldName: dicomRecordsController.fileUploadFieldName,
+  fileMaxSize: FILE_UPLOAD_MAX_SIZE,
+});
 
 const app = express();
 
-useRoutes({dicomRecordsController, fileUploadService}, app);
+useRoutes(
+  {
+    dicomFileUploadService,
+    dicomRecordCreateValidator,
+    dicomRecordsController,
+  },
+  app,
+);
 
 module.exports = {app};

--- a/src/app.js
+++ b/src/app.js
@@ -1,9 +1,23 @@
 const express = require('express');
 
+const {
+  FILE_UPLOAD_DESTINATION,
+  FILE_UPLOAD_MAX_SIZE,
+} = require('./config/file-upload-config');
+const {
+  DICOMRecordsController,
+} = require('./controllers/dicom-records-controller');
+const {FileUploadService} = require('./services/file-upload-service');
 const {useRoutes} = require('./routes');
+
+const fileUploadService = new FileUploadService({
+  destination: FILE_UPLOAD_DESTINATION,
+  maxFileSize: FILE_UPLOAD_MAX_SIZE,
+});
+const dicomRecordsController = new DICOMRecordsController();
 
 const app = express();
 
-useRoutes(app);
+useRoutes({dicomRecordsController, fileUploadService}, app);
 
 module.exports = {app};

--- a/src/app.js
+++ b/src/app.js
@@ -1,0 +1,9 @@
+const express = require('express');
+
+const {useRoutes} = require('./routes');
+
+const app = express();
+
+useRoutes(app);
+
+module.exports = {app};

--- a/src/config/file-upload-config.js
+++ b/src/config/file-upload-config.js
@@ -1,0 +1,5 @@
+const FILE_UPLOAD_DESTINATION = 'tmp/uploads/';
+// 10 MB
+const FILE_UPLOAD_MAX_SIZE = 10 * 1024 * 1024;
+
+module.exports = {FILE_UPLOAD_DESTINATION, FILE_UPLOAD_MAX_SIZE};

--- a/src/controllers/dicom-records-controller.js
+++ b/src/controllers/dicom-records-controller.js
@@ -1,0 +1,23 @@
+const {DICOMRecord} = require('../models/dicom-record');
+const {
+  serializeDICOMRecord,
+} = require('../serializers/dicom-record-serializer');
+
+/**
+ * DICOM records controller
+ */
+class DICOMRecordsController {
+  /**
+   * Allows user to create DICOM records
+   *
+   * @param {import('express').Request} req The Express request
+   * @param {import('express').Response} res The Express response
+   */
+  create(_req, res) {
+    const record = new DICOMRecord();
+
+    res.status(201).json({data: serializeDICOMRecord(record)});
+  }
+}
+
+module.exports = {DICOMRecordsController};

--- a/src/controllers/dicom-records-controller.js
+++ b/src/controllers/dicom-records-controller.js
@@ -7,6 +7,10 @@ const {
  * DICOM records controller
  */
 class DICOMRecordsController {
+  constructor() {
+    this.fileUploadFieldName = 'dicomFile';
+  }
+
   /**
    * Allows user to create DICOM records
    *

--- a/src/controllers/dicom-records-controller.js
+++ b/src/controllers/dicom-records-controller.js
@@ -17,8 +17,8 @@ class DICOMRecordsController {
    * @param {import('express').Request} req The Express request
    * @param {import('express').Response} res The Express response
    */
-  create(_req, res) {
-    const record = new DICOMRecord();
+  create(req, res) {
+    const record = DICOMRecord.fromFile(req.file);
 
     res.status(201).json({data: serializeDICOMRecord(record)});
   }

--- a/src/index.js
+++ b/src/index.js
@@ -1,12 +1,6 @@
-const express = require('express');
-
-const app = express();
+const {app} = require('./app');
 
 const port = process.env.PORT || 3000;
-
-app.get('/', (req, res) => {
-  res.send('Hello World!');
-});
 
 app.listen(port, () => {
   console.log(`🚀 Example app listening on port ${port}`);

--- a/src/models/dicom-record.js
+++ b/src/models/dicom-record.js
@@ -1,0 +1,9 @@
+const {v4} = require('uuid');
+
+class DICOMRecord {
+  constructor(attrs = {}) {
+    this.id = attrs.id || v4();
+  }
+}
+
+module.exports = {DICOMRecord};

--- a/src/models/dicom-record.js
+++ b/src/models/dicom-record.js
@@ -1,8 +1,23 @@
 const {v4} = require('uuid');
 
 class DICOMRecord {
+  /**
+   *
+   * @param {Express.Multer.File} file Uploaded file
+   */
+  static fromFile(file) {
+    return new DICOMRecord({
+      fileOriginalName: file.originalname,
+      fileUploadedAt: new Date(),
+      fileUrl: file.path,
+    });
+  }
+
   constructor(attrs = {}) {
     this.id = attrs.id || v4();
+    this.fileOriginalName = attrs.fileOriginalName || null;
+    this.fileUrl = attrs.fileUrl || null;
+    this.fileUploadedAt = attrs.fileUploadedAt || null;
   }
 }
 

--- a/src/models/validation-error.js
+++ b/src/models/validation-error.js
@@ -1,0 +1,35 @@
+/**
+ * Validation error model.
+ */
+class ValidationError {
+  constructor(attrs = {}) {
+    /**
+     * The error code
+     * @type {string}
+     */
+    this.code = attrs.code;
+    /**
+     * The field where the error happpened
+     * @type {string}
+     */
+    this.field = attrs.field;
+    /**
+     * The human-readable error message
+     * @type {string}
+     */
+    this.message = attrs.message;
+  }
+
+  /**
+   * Serialize error to JSON for response
+   */
+  toJSON() {
+    return {
+      code: this.code,
+      field: this.field,
+      message: this.message,
+    };
+  }
+}
+
+module.exports = {ValidationError};

--- a/src/routes.js
+++ b/src/routes.js
@@ -1,0 +1,18 @@
+const {
+  DICOMRecordsController,
+} = require('./controllers/dicom-records-controller');
+
+/**
+ * Attach routes to Express app
+ *
+ * @param {import('express').Express} app The Express app
+ */
+function useRoutes(app) {
+  const dicomRecordsController = new DICOMRecordsController();
+
+  app
+    .route('/dicom-records')
+    .post((req, res) => dicomRecordsController.create(req, res));
+}
+
+module.exports = {useRoutes};

--- a/src/routes.js
+++ b/src/routes.js
@@ -2,16 +2,25 @@
  * Attach routes to Express app
  *
  * @param {object} deps The injected dependencies
- * @param {DICOMRecordsController} deps.dicomRecordsController The DICOM records controller
+ * @param {import('./controllers/dicom-records-controller').DICOMRecordsController} deps.dicomRecordsController The DICOM records controller
+ * @param {import('./services/file-upload-service').FileUploadService} deps.dicomFileUploadService The DICOM file upload service
+ * @param {import('./validators/dicom-record-create-validator').DICOMRecordCreateValidator} deps.dicomRecordCreateValidator The DICOM record create validator
  * @param {import('express').Express} app The Express app
  */
 function useRoutes(deps, app) {
-  const {dicomRecordsController, fileUploadService} = deps;
+  const {
+    dicomFileUploadService,
+    dicomRecordCreateValidator,
+    dicomRecordsController,
+  } = deps;
 
   app
     .route('/dicom-records')
     .post(
-      fileUploadService.middleware(dicomRecordsController.fileUploadAttribute),
+      [
+        dicomFileUploadService.middleware(),
+        dicomRecordCreateValidator.middleware(),
+      ],
       (req, res) => dicomRecordsController.create(req, res),
     );
 }

--- a/src/routes.js
+++ b/src/routes.js
@@ -1,18 +1,19 @@
-const {
-  DICOMRecordsController,
-} = require('./controllers/dicom-records-controller');
-
 /**
  * Attach routes to Express app
  *
+ * @param {object} deps The injected dependencies
+ * @param {DICOMRecordsController} deps.dicomRecordsController The DICOM records controller
  * @param {import('express').Express} app The Express app
  */
-function useRoutes(app) {
-  const dicomRecordsController = new DICOMRecordsController();
+function useRoutes(deps, app) {
+  const {dicomRecordsController, fileUploadService} = deps;
 
   app
     .route('/dicom-records')
-    .post((req, res) => dicomRecordsController.create(req, res));
+    .post(
+      fileUploadService.middleware(dicomRecordsController.fileUploadAttribute),
+      (req, res) => dicomRecordsController.create(req, res),
+    );
 }
 
 module.exports = {useRoutes};

--- a/src/serializers/dicom-record-serializer.js
+++ b/src/serializers/dicom-record-serializer.js
@@ -1,0 +1,7 @@
+function serializeDICOMRecord(dicomRecord) {
+  return {
+    id: dicomRecord.id,
+  };
+}
+
+module.exports = {serializeDICOMRecord};

--- a/src/serializers/dicom-record-serializer.js
+++ b/src/serializers/dicom-record-serializer.js
@@ -1,6 +1,10 @@
 function serializeDICOMRecord(dicomRecord) {
   return {
     id: dicomRecord.id,
+    fileUploadedAt: dicomRecord.fileUploadedAt
+      ? dicomRecord.fileUploadedAt.toISOString()
+      : null,
+    fileUrl: dicomRecord.fileUrl,
   };
 }
 

--- a/src/services/file-upload-service.js
+++ b/src/services/file-upload-service.js
@@ -8,12 +8,12 @@ class FileUploadService {
   /**
    * @param {object} options File upload service options
    * @param {string} options.destination Destination the files will be uploaded on disk
-   * @param {number} options.maxFileSize Max file size for an upload
-   *
+   * @param {number} options.fileMaxSize File max size for an upload
+   * @param {string} options.fileFieldName The field name on the Express request body for the file
    */
   constructor(options = {}) {
     const destination = options.destination || 'tmp/uploads/';
-    const maxFileSize = options.maxFileSize;
+    const fileMaxSize = options.fileMaxSize;
     const storage = multer.diskStorage({
       destination,
       filename: (_req, _file, cb) => {
@@ -21,21 +21,20 @@ class FileUploadService {
       },
     });
 
+    this.fileFieldName = options.fileFieldName || 'file';
     this.uploader = multer({
       storage,
-      ...(maxFileSize
+      ...(fileMaxSize
         ? {
-            limits: {fileSize: maxFileSize},
+            limits: {fileSize: fileMaxSize},
           }
         : {}),
     });
+    this.middleware = this.middleware.bind(this);
   }
 
-  /**
-   * @param {string} attribute Name of the multipart form field to process.
-   */
-  middleware(attribute = 'file') {
-    return this.uploader.single(attribute);
+  middleware() {
+    return this.uploader.single(this.fileFieldName);
   }
 }
 

--- a/src/services/file-upload-service.js
+++ b/src/services/file-upload-service.js
@@ -1,0 +1,42 @@
+const multer = require('multer');
+const {v4} = require('uuid');
+
+/**
+ * Service for uploading files to a store
+ */
+class FileUploadService {
+  /**
+   * @param {object} options File upload service options
+   * @param {string} options.destination Destination the files will be uploaded on disk
+   * @param {number} options.maxFileSize Max file size for an upload
+   *
+   */
+  constructor(options = {}) {
+    const destination = options.destination || 'tmp/uploads/';
+    const maxFileSize = options.maxFileSize;
+    const storage = multer.diskStorage({
+      destination,
+      filename: (_req, _file, cb) => {
+        cb(null, v4());
+      },
+    });
+
+    this.uploader = multer({
+      storage,
+      ...(maxFileSize
+        ? {
+            limits: {fileSize: maxFileSize},
+          }
+        : {}),
+    });
+  }
+
+  /**
+   * @param {string} attribute Name of the multipart form field to process.
+   */
+  middleware(attribute = 'file') {
+    return this.uploader.single(attribute);
+  }
+}
+
+module.exports = {FileUploadService};

--- a/src/validators/dicom-record-create-validator.js
+++ b/src/validators/dicom-record-create-validator.js
@@ -1,0 +1,52 @@
+const {ValidationError} = require('../models/validation-error');
+
+/**
+ * Validator for creating DICOM records
+ */
+class DICOMRecordCreateValidator {
+  /**
+   * @param {object} options Validator options
+   * @param {string} options.fileFieldName The field name on the Express request body for the file
+   */
+  constructor(options = {}) {
+    this.fileFieldName = options.fileFieldName;
+    /**
+     * List of validation errors
+     * @type {ValidationError[]}
+     */
+    this.errors = [];
+    this.middleware = this.middleware.bind(this);
+    this.validate = this.validate.bind(this);
+  }
+
+  middleware() {
+    return this.validate;
+  }
+
+  /**
+   *
+   * @param {import('express').Request} req The Express request
+   * @param {import('express').Response} res The Express response
+   * @param {import('express').NextFunction} next The Express next function
+   */
+  validate(req, res, next) {
+    if (!req.file) {
+      this.errors.push(
+        new ValidationError({
+          code: 'required',
+          field: this.fileFieldName,
+          message: 'A file is required',
+        }),
+      );
+    }
+
+    if (this.errors.length === 0) {
+      // eslint-disable-next-line node/callback-return
+      next();
+    } else {
+      res.status(422).json({errors: this.errors.map((err) => err.toJSON())});
+    }
+  }
+}
+
+module.exports = {DICOMRecordCreateValidator};

--- a/test/controllers/dicom-records-controller.test.js
+++ b/test/controllers/dicom-records-controller.test.js
@@ -1,11 +1,19 @@
+const express = require('express');
 const request = require('supertest');
 
-const {app} = require('../../src/app');
+const {
+  DICOMRecordsController,
+} = require('../../src/controllers/dicom-records-controller');
+
+const controller = new DICOMRecordsController();
+const mockApp = express();
+
+mockApp.post('/', (req, res) => controller.create(req, res));
 
 describe('DICOMRecordsController', () => {
   describe('create()', () => {
     it('responds with a DICOM record when DICOM file is valid', async () => {
-      const res = await request(app).post('/dicom-records');
+      const res = await request(mockApp).post('/');
 
       expect(res.statusCode).toBe(201);
       expect(res.body).toStrictEqual({data: {id: expect.any(String)}});

--- a/test/controllers/dicom-records-controller.test.js
+++ b/test/controllers/dicom-records-controller.test.js
@@ -1,22 +1,55 @@
 const express = require('express');
 const request = require('supertest');
+const multer = require('multer');
 
+const {FileUploadService} = require('../../src/services/file-upload-service');
 const {
   DICOMRecordsController,
 } = require('../../src/controllers/dicom-records-controller');
 
-const controller = new DICOMRecordsController();
-const mockApp = express();
+jest.mock('multer');
 
-mockApp.post('/', (req, res) => controller.create(req, res));
+multer.mockImplementation(() => {
+  return {
+    single() {
+      return (req, res, next) => {
+        req.body = {title: req.query.title};
+        req.file = {
+          originalname: 'IM00001',
+          mimetype: 'application/octet-stream',
+          path: '/tmp/dicom',
+        };
+        return next();
+      };
+    },
+  };
+});
+
+const controller = new DICOMRecordsController();
+const fileService = new FileUploadService({
+  fileFieldName: controller.fileUploadFieldName,
+});
+const mockApp = express();
+mockApp.post('/', [fileService.middleware()], (req, res) =>
+  controller.create(req, res),
+);
 
 describe('DICOMRecordsController', () => {
   describe('create()', () => {
+    jest.useFakeTimers();
+    jest.setSystemTime(new Date('2024-03-14T00:00:00.000Z'));
+
     it('responds with a DICOM record when DICOM file is valid', async () => {
       const res = await request(mockApp).post('/');
 
       expect(res.statusCode).toBe(201);
-      expect(res.body).toStrictEqual({data: {id: expect.any(String)}});
+      expect(res.body).toStrictEqual({
+        data: {
+          id: expect.any(String),
+          fileUploadedAt: '2024-03-14T00:00:00.000Z',
+          fileUrl: '/tmp/dicom',
+        },
+      });
     });
   });
 });

--- a/test/controllers/dicom-records-controller.test.js
+++ b/test/controllers/dicom-records-controller.test.js
@@ -1,0 +1,14 @@
+const request = require('supertest');
+
+const {app} = require('../../src/app');
+
+describe('DICOMRecordsController', () => {
+  describe('create()', () => {
+    it('responds with a DICOM record when DICOM file is valid', async () => {
+      const res = await request(app).post('/dicom-records');
+
+      expect(res.statusCode).toBe(201);
+      expect(res.body).toStrictEqual({data: {id: expect.any(String)}});
+    });
+  });
+});

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1,5 +1,0 @@
-describe('index', () => {
-  it('passes', () => {
-    expect(1).toBe(1);
-  });
-});

--- a/test/models/dicom-record.test.js
+++ b/test/models/dicom-record.test.js
@@ -1,0 +1,31 @@
+const {DICOMRecord} = require('../../src/models/dicom-record');
+
+describe('DICOMRecord', () => {
+  jest.useFakeTimers();
+  jest.setSystemTime(new Date('2024-03-14T00:00:00.000Z'));
+
+  it("assigns an id if one isn't provided", () => {
+    const record = new DICOMRecord();
+
+    expect(record.id).toBeDefined();
+  });
+
+  describe('fromFile()', () => {
+    it('assigns the file attributes', () => {
+      const mockFile = {
+        originalname: 'IM0001',
+        path: '/tmp/uploads/b87cdc09-1d32-4db2-a34c-ec479e391f9e',
+      };
+      const record = DICOMRecord.fromFile(mockFile);
+
+      expect(record.id).toBeDefined();
+      expect(record.fileUploadedAt.toISOString()).toBe(
+        '2024-03-14T00:00:00.000Z',
+      );
+      expect(record.fileOriginalName).toBe('IM0001');
+      expect(record.fileUrl).toBe(
+        '/tmp/uploads/b87cdc09-1d32-4db2-a34c-ec479e391f9e',
+      );
+    });
+  });
+});

--- a/test/serializers/dicom-record-serializer.test.js
+++ b/test/serializers/dicom-record-serializer.test.js
@@ -1,0 +1,23 @@
+const {DICOMRecord} = require('../../src/models/dicom-record');
+const {
+  serializeDICOMRecord,
+} = require('../../src/serializers/dicom-record-serializer');
+
+describe('serializeDICOMRecord()', () => {
+  jest.useFakeTimers();
+  jest.setSystemTime(new Date('2024-03-14T00:00:00.000Z'));
+
+  it('serializes the DICOM record to JSON', () => {
+    const record = new DICOMRecord({
+      fileOriginalName: 'IM00001',
+      fileUploadedAt: new Date(),
+      fileUrl: '/tmp/uploads/1',
+    });
+
+    expect(serializeDICOMRecord(record)).toStrictEqual({
+      id: expect.any(String),
+      fileUploadedAt: '2024-03-14T00:00:00.000Z',
+      fileUrl: '/tmp/uploads/1',
+    });
+  });
+});

--- a/test/validators/dicom-record-create-validator.test.js
+++ b/test/validators/dicom-record-create-validator.test.js
@@ -1,0 +1,53 @@
+const {
+  DICOMRecordCreateValidator,
+} = require('../../src/validators/dicom-record-create-validator');
+
+describe('DICOMRecordCreateValidator', () => {
+  let validator;
+
+  beforeEach(() => {
+    validator = new DICOMRecordCreateValidator({fileFieldName: 'file'});
+  });
+
+  describe('validate()', () => {
+    it('requires the file to be uploaded on the request', () => {
+      const req = {};
+      const resStatus = jest.fn();
+      const resJson = jest.fn();
+      const res = {
+        status: resStatus.mockImplementation(() => ({json: resJson})),
+      };
+      const next = jest.fn();
+
+      validator.validate(req, res, next);
+
+      expect(resStatus).toHaveBeenCalledWith(422);
+      expect(resJson).toHaveBeenCalledWith({
+        errors: [
+          {
+            code: 'required',
+            field: 'file',
+            message: 'A file is required',
+          },
+        ],
+      });
+    });
+
+    it('continues to next middleware when request is valid with a file', () => {
+      const req = {
+        file: true,
+      };
+      const resStatus = jest.fn();
+      const resJson = jest.fn();
+      const res = {
+        status: resStatus.mockImplementation(() => ({json: resJson})),
+      };
+      const next = jest.fn();
+
+      validator.validate(req, res, next);
+
+      expect(next).toHaveBeenCalled();
+      expect(resStatus).not.toHaveBeenCalled();
+    });
+  });
+});


### PR DESCRIPTION
## Description

Adds services to server for handling storing the DICOM file locally on disk storage, validating the request and returning a DICOM record from memory.

## Testing

Test using Postman.

- Start the server with `npm run dev`
- Set up a POST request to `localhost:3000/dicom-records`
- Set the "Body" to "form-data" and attach a DICOM file to a field named `dicomFile`
- You should see a DICOM record returned with some fields