### PR TITLE
feat: dicom viewer

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "dicom-parser": "1.8.21",
         "express": "4.18.3",
         "multer": "1.4.5-lts.1",
+        "pngjs": "7.0.0",
         "sequelize": "6.37.1",
         "sqlite3": "5.1.7",
         "uuid": "9.0.1"
@@ -9463,6 +9464,14 @@
       "dev": true,
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/pngjs": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/pngjs/-/pngjs-7.0.0.tgz",
+      "integrity": "sha512-LKWqWJRhstyYo9pGvgor/ivk2w94eSjE3RGVuzLGlr3NmD8bf7RcYGze1mNdEHRP6TRP6rMuDHk5t44hnTRyow==",
+      "engines": {
+        "node": ">=14.19.0"
       }
     },
     "node_modules/possible-typed-array-names": {

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "dicom-parser": "1.8.21",
     "express": "4.18.3",
     "multer": "1.4.5-lts.1",
+    "pngjs": "7.0.0",
     "sequelize": "6.37.1",
     "sqlite3": "5.1.7",
     "uuid": "9.0.1"

--- a/src/app.js
+++ b/src/app.js
@@ -10,6 +10,7 @@ const {
 const {FileUploadService} = require('./services/file-upload-service');
 const {DICOMReaderService} = require('./services/dicom-reader-service');
 const {DICOMRecordsService} = require('./services/dicom-records-service');
+const {DICOMViewerService} = require('./services/dicom-viewer-service');
 const {
   DICOMRecordCreateValidator,
 } = require('./validators/dicom-record-create-validator');
@@ -20,8 +21,10 @@ const {
 
 const dicomReaderService = new DICOMReaderService();
 const dicomRecordsService = new DICOMRecordsService({dicomReaderService});
+const dicomViewerService = new DICOMViewerService({dicomReaderService});
 const dicomRecordsController = new DICOMRecordsController({
   dicomRecordsService,
+  dicomViewerService,
 });
 const dicomGetAttributeValidator = new DICOMGetAttributeValidator();
 const dicomRecordCreateValidator = new DICOMRecordCreateValidator({

--- a/src/controllers/dicom-records-controller.js
+++ b/src/controllers/dicom-records-controller.js
@@ -36,6 +36,7 @@ class DICOMRecordsController {
    * @param {import('express').Response} res The Express response
    */
   async getDICOMAttribute(req, res) {
+  async getTag(req, res) {
     const record = await this.dicomRecordsService.findById(req.params.id);
 
     if (!record) {
@@ -51,7 +52,7 @@ class DICOMRecordsController {
     }
 
     const ge = req.query.ge;
-    const tag = await this.dicomRecordsService.getDICOMTag(record, ge);
+    const tag = this.dicomRecordsService.getDICOMTag(record, ge);
 
     if (!tag) {
       res.status(404).json({

--- a/src/data/dicom-tag-dict.js
+++ b/src/data/dicom-tag-dict.js
@@ -1,5 +1,6 @@
 const DICOM_TAG_DICTIONARY = {
   AccessionNumber: 'x00080050',
+  Columns: 'x00280011',
   ImageType: 'x00080008',
   InstitutionAddress: 'x00080081',
   InstitutionName: 'x00080080',
@@ -7,9 +8,13 @@ const DICOM_TAG_DICTIONARY = {
   PatientID: 'x00100020',
   PatientName: 'x00100010',
   PatientSex: 'x00100040',
+  PixelData: 'x7fe00010',
   ReferringPhysicianName: 'x00080090',
+  Rows: 'x00280010',
   SOPClassUID: 'x00080016',
   SOPInstanceUID: 'x00080018',
+  WindowCenter: 'x00281050',
+  WindowWidth: 'x00281051',
 };
 
 const DICOM_COMMON_TAG_DICTIONARY = {

--- a/src/routes.js
+++ b/src/routes.js
@@ -26,6 +26,10 @@ function useRoutes(deps, app) {
       (req, res) => dicomRecordsController.create(req, res),
     );
 
+  app.route('/dicom-records/:id.png').get((req, res) => {
+    dicomRecordsController.viewAsImage(req, res);
+  });
+
   app
     .route('/dicom-records/:id/attr')
     .get(dicomGetAttributeValidator.middleware(), (req, res) =>

--- a/src/routes.js
+++ b/src/routes.js
@@ -29,7 +29,7 @@ function useRoutes(deps, app) {
   app
     .route('/dicom-records/:id/attr')
     .get(dicomGetAttributeValidator.middleware(), (req, res) =>
-      dicomRecordsController.getDICOMAttribute(req, res),
+      dicomRecordsController.getTag(req, res),
     );
 }
 

--- a/src/services/dicom-records-service.js
+++ b/src/services/dicom-records-service.js
@@ -51,8 +51,10 @@ class DICOMRecordsService {
     return newRecord;
   }
 
-  findById(id, options) {
-    return DICOMRecord.findByPk(id, options);
+  findById(id) {
+    return DICOMRecord.findByPk(id, {
+      include: [DICOMFile],
+    });
   }
 
   /**

--- a/src/services/dicom-viewer-service.js
+++ b/src/services/dicom-viewer-service.js
@@ -1,0 +1,130 @@
+const {existsSync, writeFileSync} = require('fs');
+
+const {PNG} = require('pngjs');
+
+const {DICOM_TAG_DICTIONARY} = require('../data/dicom-tag-dict');
+
+const DEFAULT_WINDOW_CENTER = 128;
+const DEFAULT_WINDOW_WIDTH = 256;
+
+/**
+ * Service for reading DICOM files and tags
+ */
+class DICOMViewerService {
+  /**
+   *
+   * @param {object} deps Injected dependencies
+   * @param {import('./dicom-reader-service').DICOMReaderService} deps.dicomReaderService The DICOM reader service
+   */
+  constructor(deps = {}) {
+    this.dicomReaderService = deps.dicomReaderService;
+  }
+
+  /**
+   * View DICOMFile as a PNG
+   *
+   * @param {import('../models/dicom-file').DICOMFile} file The DICOM file
+   *
+   * @returns
+   */
+  viewAsPNG(file) {
+    const pngPath = this.getPNGPath(file);
+
+    if (this.hasCachedPNG(pngPath)) {
+      return {path: pngPath, cached: true};
+    }
+
+    this.createPNG(pngPath, file);
+
+    return {path: pngPath, cached: false};
+  }
+
+  /**
+   * Create a PNG version of the DICOM file
+   *
+   * @param {string} path The PNG file path
+   * @param {import('../models/dicom-file').DICOMFile} file The DICOM file
+   *
+   * @returns {string} The PNG file path
+   */
+  createPNG(path, file) {
+    const dataSet = this.dicomReaderService.parseDICOMFile(file.url);
+    const pixelDataElement = dataSet.elements[DICOM_TAG_DICTIONARY.PixelData];
+    const pixelData = new Uint16Array(
+      dataSet.byteArray.buffer,
+      pixelDataElement.dataOffset,
+      pixelDataElement.length / 2,
+    );
+
+    const width = dataSet.uint16(DICOM_TAG_DICTIONARY.Columns);
+    const height = dataSet.uint16(DICOM_TAG_DICTIONARY.Rows);
+    let windowCenter = parseFloat(
+      dataSet.string(DICOM_TAG_DICTIONARY.WindowCenter),
+    );
+    let windowWidth = parseFloat(
+      dataSet.string(DICOM_TAG_DICTIONARY.WindowWidth),
+    );
+    windowCenter = isNaN(windowCenter) ? DEFAULT_WINDOW_CENTER : windowCenter;
+    windowWidth = isNaN(windowWidth) ? DEFAULT_WINDOW_WIDTH : windowWidth;
+
+    const png = new PNG({width, height, filterType: -1});
+
+    for (let y = 0; y < height; y++) {
+      for (let x = 0; x < width; x++) {
+        const idx = width * y + x;
+        const pixelValue = pixelData[idx];
+        let intensity = 0;
+
+        if (pixelValue <= windowCenter - 0.5 - (windowWidth - 1) / 2) {
+          // Black
+          intensity = 0;
+        } else if (pixelValue > windowCenter - 0.5 + (windowWidth - 1) / 2) {
+          // White
+          intensity = 255;
+        } else {
+          // Gray
+          intensity =
+            ((pixelValue - (windowCenter - 0.5)) / (windowWidth - 1) + 0.5) *
+            255;
+        }
+
+        const pngIdx = idx << 2;
+        png.data[pngIdx] = intensity;
+        png.data[pngIdx + 1] = intensity;
+        png.data[pngIdx + 2] = intensity;
+        // Fully opaque
+        png.data[pngIdx + 3] = 0xff;
+      }
+    }
+
+    const pngBuffer = PNG.sync.write(png);
+
+    writeFileSync(path, pngBuffer);
+
+    return path;
+  }
+
+  /**
+   * Builds file path for PNG from DICOM file
+   *
+   * @param {import('../models/dicom-file').DICOMFile} file The DICOM file
+   *
+   * @returns {string} The PNG file path
+   */
+  getPNGPath(file) {
+    return `${file.url}-${file.checksum}.png`;
+  }
+
+  /**
+   * Checks if the PNG already exists in cache
+   *
+   * @param {string} path The PNG file path
+   *
+   * @returns {boolean} Whether the PNG exists in cache or not
+   */
+  hasCachedPNG(path) {
+    return existsSync(path);
+  }
+}
+
+module.exports = {DICOMViewerService};

--- a/test/controllers/dicom-records-controller.test.js
+++ b/test/controllers/dicom-records-controller.test.js
@@ -74,7 +74,7 @@ describe('DICOMRecordsController', () => {
     });
   });
 
-  describe('getDICOMAttribute()', () => {
+  describe('getTag()', () => {
     it('responds with a DICOM tag when record is found and ge matches', async () => {
       // Given
       const record = new DICOMRecord({
@@ -95,7 +95,7 @@ describe('DICOMRecordsController', () => {
       };
 
       // When
-      await controller.getDICOMAttribute(req, res);
+      await controller.getTag(req, res);
 
       // Then
       expect(resStatus).toHaveBeenCalledWith(200);
@@ -121,7 +121,7 @@ describe('DICOMRecordsController', () => {
       };
 
       // When
-      await controller.getDICOMAttribute(req, res);
+      await controller.getTag(req, res);
 
       // Then
       expect(resStatus).toHaveBeenCalledWith(404);
@@ -147,7 +147,7 @@ describe('DICOMRecordsController', () => {
       };
 
       // When
-      await controller.getDICOMAttribute(req, res);
+      await controller.getTag(req, res);
 
       // Then
       expect(resStatus).toHaveBeenCalledWith(404);


### PR DESCRIPTION
## Description

Adds a new service for viewing DICOM files as an image. I spent a bit of time reading [Chapter 12 - Pixel Data](https://dicomiseasy.blogspot.com/2012/08/chapter-12-pixel-data.html) to see if I could produce the image myself. It turns out to be a little over my head in terms of understanding all the pixel data and manipulating it based on the DICOM tags. I've gotten to the point where it'll show the image, but with the wrong orientation. Realistically, I'd use a library that is battle-tested for this. I was mostly curious how the pixel data stored in the DICOM would work.

I've also made sure that the PNG is only produced on-demand the first time. Subsequent requests return the same PNG. It's namespaced by the file checksum, so if the file were modified, the cache would be busted. I could have also used the updatedAt timestamp. I'm just unfamiliar with how 

## Testing

Test using Postman.

- Start the server with `npm run dev`
- Set up a POST request to `localhost:3000/dicom-records`
- Set the "Body" to "form-data" and attach a DICOM file to a field named `dicomFile`
- Next, set a GET request to `localhost:3000/dicom-records/{ID}.png`  with the ID you received from the POST request
- You should see an image render
- Make the same request against and you'll see the response time decrease since it's served from the same image